### PR TITLE
fixes 'post is created' automation action firing multiple times on creation and update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,9 @@
 
 #### Fixed
 
-- Minor style fixes on the Settings admin page.
+- Automation actions firing multiple times or never at all for the *Post is Created* event. The `'transition_post_status'` action hook is now used instead of `'wp_insert_post'`.
 - Large images that failed to load would overflow the container in Project Embeds.
+- Minor style fix on the Settings admin page.
 
 ### 3.9.1 - 2023-07-28
 

--- a/src/includes/automations/class-events.php
+++ b/src/includes/automations/class-events.php
@@ -69,29 +69,23 @@ if ( ! class_exists( __NAMESPACE__ . '\Events' ) ) {
 				add_action( 'transition_post_status', function( $new_status, $old_status, $the_post ) {
 					if (
 						$old_status !== $new_status &&
-						false === wp_is_post_revision( $the_post ) &&
 						in_array( $old_status, array( 'new', 'auto-draft' ), true ) &&
-						! in_array( $new_status, array( 'new', 'auto-draft' ), true )
-					) {
-						$automation_ids = Data::get_all_automation_ids_for( 'wp_insert_post' );
-						if ( count( $automation_ids ) > 0 ) {
-							foreach ( $automation_ids as $id ) {
-								trigger_error( "Checking Automation {$id} to run actions..." );
-								( new Automation( $id, [ 'post' => $the_post ] ) )->maybe_run_actions();
-							}
-						}
-					}
-				}, 10, 3 );
-				add_action( 'wp_insert_post', function( $post_id, $the_post, $update = true ) {
-					if (
-						! $update &&
-						'auto-draft' != $the_post->post_status &&
+						! in_array( $new_status, array( 'new', 'auto-draft' ), true ) &&
 						false === wp_is_post_revision( $the_post )
 					) {
+						/**
+						 * Note that the original hook for 'Post is Created'
+						 * was 'wp_insert_post' but this proved to cause
+						 * duplicate or missed executions. This now makes
+						 * no sense in the database, but it's more semantic
+						 * than 'transition_post_status' so I still prefer it.
+						 *
+						 * @since [unreleased]
+						 * @ignore
+						 */
 						$automation_ids = Data::get_all_automation_ids_for( 'wp_insert_post' );
 						if ( count( $automation_ids ) > 0 ) {
 							foreach ( $automation_ids as $id ) {
-								trigger_error( "Checking Automation {$id} to run actions..." );
 								( new Automation( $id, [ 'post' => $the_post ] ) )->maybe_run_actions();
 							}
 						}


### PR DESCRIPTION
Needs testing for compatibility with custom post types by third-party plugins like Elementor, WooCommerce, ACF, etc...