### PR TITLE
Plugin version checker to migrate data + admin notices

### DIFF
--- a/completionist.php
+++ b/completionist.php
@@ -121,11 +121,13 @@ foreach ( glob( PLUGIN_PATH . 'src/public/class-*.php' ) as $file ) {
 	require_once $file;
 }
 
+Admin_Notices::register();
 Freemius::register();
 Request_Token::register();
 REST_Server::register();
 Shortcodes::register();
 Uninstaller::register();
+Upgrader::register();
 
 // Register admin functionality.
 if ( is_admin() ) {

--- a/completionist.php
+++ b/completionist.php
@@ -7,7 +7,7 @@
  * @license           GPL-3.0-or-later
  *
  * @wordpress-plugin
- * Plugin Name:       Completionist
+ * Plugin Name:       Completionist – Asana for WordPress
  * Plugin URI:        https://purpleturtlecreative.com/completionist/
  * Description:       Manage, pin, automate, and display Asana tasks in relevant areas of your WordPress admin and website frontend.
  * Version:           4.0.0
@@ -16,13 +16,13 @@
  * Tested up to:      6.3
  * Author:            Purple Turtle Creative
  * Author URI:        https://purpleturtlecreative.com/
- * License:           GPL v3 or later
+ * License:           GPL v3
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 /*
-This program is open-source software: you can redistribute it and/or modify
-it UNDER THE TERMS of the GNU General Public License as published by
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
@@ -32,7 +32,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.txt.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 namespace PTC_Completionist;

--- a/completionist.php
+++ b/completionist.php
@@ -16,7 +16,7 @@
  * Tested up to:      6.3
  * Author:            Purple Turtle Creative
  * Author URI:        https://purpleturtlecreative.com/
- * License:           GPL v3
+ * License:           GPL v3 or later
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.txt
  */
 

--- a/src/includes/abstracts/class-plugin-version-checker.php
+++ b/src/includes/abstracts/class-plugin-version-checker.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Upgrader class
+ * Plugin Version Checker class
+ *
+ * @todo Update Admin Notices messages to link to the Freemius
+ * support form page instead of my exact email. I need to also
+ * test how this form actually works in the Freemius backend.
  *
  * @since [unreleased]
  */
@@ -21,11 +25,13 @@ require_once \PTC_Completionist\PLUGIN_PATH . 'src/public/class-admin-notices.ph
  *
  * @since [unreleased]
  */
-abstract class Plugin_Version_Upgrader {
+abstract class Plugin_Version_Checker {
 
 	/**
 	 * The option name storing the last successfully upgraded
 	 * plugin version.
+	 *
+	 * Required to be set in child class.
 	 *
 	 * @since [unreleased]
 	 *
@@ -35,6 +41,8 @@ abstract class Plugin_Version_Upgrader {
 
 	/**
 	 * The current running plugin version.
+	 *
+	 * Required to be set in child class.
 	 *
 	 * @since [unreleased]
 	 *

--- a/src/includes/abstracts/class-plugin-version-checker.php
+++ b/src/includes/abstracts/class-plugin-version-checker.php
@@ -148,7 +148,7 @@ abstract class Plugin_Version_Checker {
 	 *
 	 * @since [unreleased]
 	 */
-	final public static function reset() {
+	final public static function delete_data() {
 		delete_option( static::get_upgraded_version_option_name() );
 	}
 

--- a/src/includes/abstracts/class-plugin-version-checker.php
+++ b/src/includes/abstracts/class-plugin-version-checker.php
@@ -6,6 +6,11 @@
  * support form page instead of my exact email. I need to also
  * test how this form actually works in the Freemius backend.
  *
+ * @todo Add plugin name value in child class to use in notices.
+ *
+ * @todo Convert member variables into abstract function stubs
+ * to ensure the values are set in the child class.
+ *
  * @since [unreleased]
  */
 
@@ -73,14 +78,6 @@ abstract class Plugin_Version_Checker {
 	 * @since [unreleased]
 	 */
 	final public static function maybe_run() {
-
-		if ( empty( static::$upgraded_version_option ) ) {
-			// Doing it wrong.
-		}
-
-		if ( empty( static::$current_plugin_version ) ) {
-			// Doing it wrong.
-		}
 
 		$last_upgraded_version = (string) get_option( static::$upgraded_version_option, '0.0.0' );
 
@@ -172,9 +169,11 @@ abstract class Plugin_Version_Checker {
 	 * @since [unreleased]
 	 *
 	 * @param string $old_version The plugin version string from
-	 * which to upgrade.
+	 * which to upgrade. (eg. '1.2.3')
 	 *
 	 * @return bool If upgraded successfully.
 	 */
 	abstract protected static function upgrade_from_version( string $old_version ) : bool;
+
+	abstract protected static function get_current_version() : string;
 }//end class

--- a/src/includes/abstracts/class-plugin-version-checker.php
+++ b/src/includes/abstracts/class-plugin-version-checker.php
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || die();
 
 use \PTC_Completionist\Admin_Notices;
 
-require_once \PTC_Completionist\PLUGIN_PATH . 'src/includes/class-util.php';
 require_once \PTC_Completionist\PLUGIN_PATH . 'src/public/class-admin-notices.php';
 
 /**
@@ -196,7 +195,7 @@ abstract class Plugin_Version_Checker {
 	 * @since [unreleased]
 	 *
 	 * @param string $old_version The plugin version string from
-	 * which to upgrade. (eg. '1.2.3')
+	 * which to upgrade.
 	 *
 	 * @return bool If upgraded successfully.
 	 */

--- a/src/includes/abstracts/class-plugin-version-upgrader.php
+++ b/src/includes/abstracts/class-plugin-version-upgrader.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Upgrader class
+ *
+ * @since [unreleased]
+ */
+
+declare(strict_types=1);
+
+namespace PTC_Completionist\Abstracts;
+
+defined( 'ABSPATH' ) || die();
+
+require_once PLUGIN_PATH . 'src/includes/class-util.php';
+
+/**
+ * Static class to handle plugin upgrades.
+ *
+ * @since [unreleased]
+ */
+abstract class Plugin_Version_Upgrader {
+
+	/**
+	 * The option name storing the last successfully upgraded
+	 * plugin version.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @var string $upgraded_version_option
+	 */
+	protected static $upgraded_version_option;
+
+	const VERSION_OPTION_NAME = '_ptc_completionist_upgraded_version';
+
+	/**
+	 * Hooks functionality into the WordPress execution flow.
+	 *
+	 * @since [unreleased]
+	 */
+	final public static function register() {
+		add_action( 'plugins_loaded', __CLASS__ . '::maybe_run' );
+	}
+
+	/**
+	 * Checks the last successfully upgraded plugin version and
+	 * runs the upgrade processes if needed.
+	 *
+	 * @since [unreleased]
+	 */
+	public static function maybe_run() {
+
+		$last_upgraded_version = (int) get_option( static::VERSION_OPTION_NAME, 0 );
+
+		if ( PLUGIN_VERSION === $last_upgraded_version ) {
+			// Plugin state is up-to-date.
+			return;
+		} elseif ( version_compare( PLUGIN_VERSION, $last_upgraded_version, '>' ) ) {
+			// Plugin state is old and needs upgrade.
+			if ( static::upgrade_from_version( $last_upgraded_version, PLUGIN_VERSION ) ) {
+				// Update option on successful upgrade.
+				update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
+			}
+		} else {
+			/*
+			The plugin was rolled back to a previous version. This is
+			not recommended and usually signals that the user is
+			experiencing issues with the latest release.
+
+			This will likely cause old plugin data to be added back,
+			so the upgrade process should run again if the plugin is
+			updated again in the future.
+
+			EDGE CASE: This will not work for users who roll back to
+			versions prior to v4.0.0. That's because this class
+			was first introduced in v4.0.0, so the database option
+			will remain set as '4.0.0' because this code doesn't exist
+			in prior versions to fix the option value. Using such an
+			old version of the plugin will also cause the uninstall
+			script to be insufficient.
+
+			If this causes issues, the user should simply uninstall
+			the plugin (from the latest installed version, if possible)
+			to completely remove all data and reset the plugin's state.
+			*/
+			update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
+		}
+	}
+
+	/**
+	 * Resets the upgrader by clearing its data.
+	 *
+	 * @since [unreleased]
+	 */
+	public static function reset() {
+		delete_option( static::VERSION_OPTION_NAME );
+	}
+
+	/**
+	 * Runs migration processes to upgrade the plugin's state from
+	 * the specified version.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @param string $old_version The plugin version string from
+	 * which to upgrade.
+	 *
+	 * @return bool If upgraded successfully.
+	 */
+	private static function upgrade_from_version( string $old_version ) : bool {
+
+		if ( version_compare( $old_version, '4.0.0', '<' ) ) {
+			// First upgrade process, so the $old_version is always zero.
+			// v4.0.0 is when plugin hosting changed from
+			// <purpleturtlecreative.com> to <wordpress.org> which
+			// removed the YahnisElsts/plugin-update-checker package.
+			if (
+				true === delete_site_option( 'external_updates-completionist' ) &&
+				false !== wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' )
+			) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		// No upgrade needed, so consider success.
+		return true;
+	}
+}//end class

--- a/src/public/class-admin-notices.php
+++ b/src/public/class-admin-notices.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Admin Notices class
+ *
+ * Despite the name, this class is registered publicly so that
+ * admin notices can be added under any context. It's simply
+ * that the notices themselves are only ever displayed in the
+ * admin context—meaning they are "notices for the admin".
+ *
+ * @todo Remove dismissed notices via AJAX from frontend. Otherwise,
+ * they never go away! Be mindful that you must prevent race conditions
+ * by making these calls atomic... If that's even possible by using
+ * a single database option_name and option_value...
+ *
+ * @since [unreleased]
+ */
+
+declare(strict_types=1);
+
+namespace PTC_Completionist;
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * A static class to manage and display admin notices.
+ */
+class Admin_Notices {
+
+	/**
+	 * The active admin notices for display.
+	 *
+	 * These are persisted in the database and loaded during the
+	 * 'admin_init' action. Unset until loaded.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @var array $notices
+	 */
+	private static $notices = array();
+
+	/**
+	 * If the admin notices have been updated in memory after
+	 * being loaded from the database.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @var bool $has_updates
+	 */
+	private static $has_updates = false;
+
+	/**
+	 * The option name for storing the active admin notices.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @var string ADMIN_NOTICES_OPTION_NAME
+	 */
+	private const ADMIN_NOTICES_OPTION_NAME = '_ptc_completionist_admin_notices';
+
+	public static function register() {
+		add_action( 'plugins_loaded', __CLASS__ . '::load_notices', \PHP_INT_MIN );
+		add_action( 'admin_notices', __CLASS__ . '::display_notices', \PHP_INT_MAX );
+		add_action( 'shutdown', __CLASS__ . '::save_notices' );
+	}
+
+	/**
+	 * @todo Prevent possible race conditions!
+	 */
+	public static function load_notices() {
+		static::$notices = get_option( static::ADMIN_NOTICES_OPTION_NAME, array() );
+	}
+
+	/**
+	 * @todo Prevent possible race conditions!
+	 */
+	public static function save_notices() {
+		if ( static::$has_updates ) {
+			update_option( static::ADMIN_NOTICES_OPTION_NAME, static::$notices );
+		}
+	}
+
+	public static function display_notices() {
+		if ( is_array( static::$notices ) && count( static::$notices ) > 0 ) {
+			foreach ( static::$notices as $id => $notice ) {
+
+				if ( ! current_user_can( $notice['capability'] ) ) {
+					// User does not have permission to read
+					// or dismiss this notice.
+					continue;
+				}
+
+				$class = "notice notice-{$notice['type']} ptc-completionist-admin-notice";
+
+				$formatted_timestamp = date_i18n(
+					get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
+					$notice['timestamp']
+				);
+
+				$message = $notice['message'];
+
+				if ( $notice['dismissible'] ) {
+					$class .= ' is-dismissible';
+				} else {
+					// Non-dismissible notices display once.
+					unset( static::$notices[ $id ] );
+					static::$has_updates = true;
+				}
+
+				printf(
+					'<div class="%1$s" data-notice-id="%2$s"><p>%3$s</p></div>',
+					esc_attr( $class ),
+					esc_attr( $id ),
+					esc_html( "[{$formatted_timestamp}] $message" )
+				);
+			}
+		}
+	}
+
+	public static function add_notice(
+		string $message,
+		string $type = 'info',
+		bool $dismissible = false,
+		string $capability = 'update_plugins'
+	) {
+		static::$notices[ uniqid() ] = array(
+			'timestamp'   => time(),
+			'message'     => $message,
+			'type'        => $type,
+			'dismissible' => $dismissible,
+			'capability'  => $capability,
+		);
+		static::$has_updates = true;
+	}
+
+	public static function clear_notices() {
+		delete_option( static::ADMIN_NOTICES_OPTION_NAME );
+	}
+}//end class

--- a/src/public/class-admin-notices.php
+++ b/src/public/class-admin-notices.php
@@ -58,28 +58,22 @@ class Admin_Notices {
 	private const ADMIN_NOTICES_OPTION_NAME = '_ptc_completionist_admin_notices';
 
 	public static function register() {
-		add_action( 'plugins_loaded', __CLASS__ . '::load_notices', \PHP_INT_MIN );
-		add_action( 'admin_notices', __CLASS__ . '::display_notices', \PHP_INT_MAX );
-		add_action( 'shutdown', __CLASS__ . '::save_notices' );
+		add_action( 'plugins_loaded', __CLASS__ . '::load', \PHP_INT_MIN );
+		add_action( 'admin_notices', __CLASS__ . '::display', \PHP_INT_MAX );
+		add_action( 'shutdown', __CLASS__ . '::save' );
 	}
 
-	/**
-	 * @todo Prevent possible race conditions!
-	 */
-	public static function load_notices() {
+	public static function load() {
 		static::$notices = get_option( static::ADMIN_NOTICES_OPTION_NAME, array() );
 	}
 
-	/**
-	 * @todo Prevent possible race conditions!
-	 */
-	public static function save_notices() {
+	public static function save() {
 		if ( static::$has_updates ) {
-			update_option( static::ADMIN_NOTICES_OPTION_NAME, static::$notices );
+			update_option( static::ADMIN_NOTICES_OPTION_NAME, static::$notices, true );
 		}
 	}
 
-	public static function display_notices() {
+	public static function display() {
 		if ( is_array( static::$notices ) && count( static::$notices ) > 0 ) {
 			foreach ( static::$notices as $id => $notice ) {
 
@@ -110,29 +104,41 @@ class Admin_Notices {
 					'<div class="%1$s" data-notice-id="%2$s"><p>%3$s</p></div>',
 					esc_attr( $class ),
 					esc_attr( $id ),
-					esc_html( "[{$formatted_timestamp}] $message" )
+					wp_kses_post( "[{$formatted_timestamp}] $message" )
 				);
 			}
 		}
 	}
 
-	public static function add_notice(
-		string $message,
-		string $type = 'info',
-		bool $dismissible = false,
-		string $capability = 'update_plugins'
-	) {
-		static::$notices[ uniqid() ] = array(
-			'timestamp'   => time(),
-			'message'     => $message,
-			'type'        => $type,
-			'dismissible' => $dismissible,
-			'capability'  => $capability,
+	public static function add( array $args = array() ) : string {
+
+		$notice = wp_parse_args(
+			$args,
+			array(
+				'id'          => uniqid(),
+				'timestamp'   => time(),
+				'message'     => '',
+				'type'        => 'info',
+				'dismissible' => false,
+				'capability'  => 'edit_posts',
+			)
 		);
+
+		static::$notices[ $args['id'] ] = $notice;
+
 		static::$has_updates = true;
+
+		return $args['id'];
 	}
 
-	public static function clear_notices() {
+	public static function remove( string $id ) {
+		if ( isset( static::$notices[ $id ] ) ) {
+			unset( static::$notices[ $id ] );
+			static::$has_updates = true;
+		}
+	}
+
+	public static function delete_all() {
 		delete_option( static::ADMIN_NOTICES_OPTION_NAME );
 	}
 }//end class

--- a/src/public/class-freemius.php
+++ b/src/public/class-freemius.php
@@ -2,6 +2,8 @@
 /**
  * Freemius class
  *
+ * @link https://github.com/Freemius/wordpress-sdk/blob/47aaeb6611c8f4c7a0a88793c0d79eafdebfbf4f/start.php#L314 Available hooks in the Freemius SDK.
+ *
  * @since 4.0.0
  */
 

--- a/src/public/class-rest-server.php
+++ b/src/public/class-rest-server.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || die();
 
 require_once PLUGIN_PATH . 'src/public/rest-api/class-projects.php';
 require_once PLUGIN_PATH . 'src/public/rest-api/class-attachments.php';
+require_once PLUGIN_PATH . 'src/public/class-admin-notices.php';
 
 /**
  * Class to register all custom REST API endpoints.
@@ -36,5 +37,6 @@ class REST_Server {
 	public static function register_routes() {
 		REST_API\Projects::register_routes();
 		REST_API\Attachments::register_routes();
+		Admin_Notices::register_routes();
 	}
 }

--- a/src/public/class-uninstaller.php
+++ b/src/public/class-uninstaller.php
@@ -80,8 +80,5 @@ class Uninstaller {
 				Database_Manager::drop_all_tables();
 			}
 		}
-
-		// Remove PUC's data. Legacy.
-		delete_site_option( 'external_updates-completionist' );
 	}
 }//end class

--- a/src/public/class-uninstaller.php
+++ b/src/public/class-uninstaller.php
@@ -11,9 +11,6 @@ namespace PTC_Completionist;
 
 defined( 'ABSPATH' ) || die();
 
-require_once PLUGIN_PATH . 'src/includes/class-options.php';
-require_once PLUGIN_PATH . 'src/includes/class-database-manager.php';
-
 /**
  * Static class to handle plugin uninstallation.
  *
@@ -65,12 +62,14 @@ class Uninstaller {
 	 */
 	public static function uninstall_current_blog() {
 
+		require_once PLUGIN_PATH . 'src/includes/class-options.php';
 		if ( class_exists( __NAMESPACE__ . '\Options' ) ) {
 			if ( method_exists( __NAMESPACE__ . '\Options', 'delete_all' ) ) {
 				Options::delete_all();
 			}
 		}
 
+		require_once PLUGIN_PATH . 'src/includes/class-database-manager.php';
 		if ( class_exists( __NAMESPACE__ . '\Database_Manager' ) ) {
 			if (
 				method_exists( __NAMESPACE__ . '\Database_Manager', 'init' )
@@ -78,6 +77,20 @@ class Uninstaller {
 			) {
 				Database_Manager::init();
 				Database_Manager::drop_all_tables();
+			}
+		}
+
+		require_once PLUGIN_PATH . 'src/public/class-admin-notices.php';
+		if ( class_exists( __NAMESPACE__ . '\Admin_Notices' ) ) {
+			if ( method_exists( __NAMESPACE__ . '\Admin_Notices', 'delete_all' ) ) {
+				Admin_Notices::delete_all();
+			}
+		}
+
+		require_once PLUGIN_PATH . 'src/public/class-upgrader.php';
+		if ( class_exists( __NAMESPACE__ . '\Upgrader' ) ) {
+			if ( method_exists( __NAMESPACE__ . '\Upgrader', 'delete_data' ) ) {
+				Upgrader::delete_data();
 			}
 		}
 	}

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -12,6 +12,7 @@ namespace PTC_Completionist;
 defined( 'ABSPATH' ) || die();
 
 require_once PLUGIN_PATH . 'src/includes/abstracts/class-plugin-version-checker.php';
+require_once PLUGIN_PATH . 'src/public/class-freemius.php';
 
 /**
  * Static class to handle plugin upgrades.
@@ -21,23 +22,49 @@ require_once PLUGIN_PATH . 'src/includes/abstracts/class-plugin-version-checker.
 class Upgrader extends Abstracts\Plugin_Version_Checker {
 
 	/**
-	 * The option name storing the last successfully upgraded
+	 * Gets the current running plugin version.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @return string
+	 */
+	protected static function get_current_plugin_version() : string {
+		return PLUGIN_VERSION;
+	}
+
+	/**
+	 * Gets the option name storing the last successfully upgraded
 	 * plugin version.
 	 *
 	 * @since [unreleased]
 	 *
-	 * @var string $upgraded_version_option
+	 * @return string
 	 */
-	protected static $upgraded_version_option = '_ptc_completionist_upgraded_version';
+	protected static function get_upgraded_version_option_name() : string {
+		return '_ptc_completionist_upgraded_version';
+	}
 
 	/**
-	 * The current running plugin version.
+	 * Gets the plugin name to display in alerts and notices.
 	 *
 	 * @since [unreleased]
 	 *
-	 * @var string $current_plugin_version
+	 * @return string
 	 */
-	protected static $current_plugin_version = PLUGIN_VERSION;
+	protected static function get_plugin_name() : string {
+		return 'Completionist';
+	}
+
+	/**
+	 * Gets the URL for the plugin's support page.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @return string
+	 */
+	protected static function get_support_link() : string {
+		return Freemius::instance()->contact_url();
+	}
 
 	/**
 	 * Runs migration processes to upgrade the plugin's state from
@@ -52,6 +79,20 @@ class Upgrader extends Abstracts\Plugin_Version_Checker {
 	 */
 	protected static function upgrade_from_version( string $old_version ) : bool {
 
+		if ( version_compare( $old_version, '3.7.0', '<' ) ) {
+			// Check installed database version.
+			require_once PLUGIN_PATH . 'src/includes/class-database-manager.php';
+			Database_Manager::init();
+			$db_version = Database_Manager::get_installed_version();
+			if ( $db_version >= 2 ) {
+				// Now that the custom request tokens database table
+				// is successfully installed, all deprecated Request
+				// Tokens (stored within postmeta) should be purged.
+				require_once PLUGIN_PATH . 'src/public/class-request-tokens.php';
+				Request_Tokens::purge_all();
+			}
+		}
+
 		if ( version_compare( $old_version, '4.0.0', '<' ) ) {
 			// First upgrade process, so the $old_version is always zero.
 			// v4.0.0 is when plugin hosting changed from
@@ -61,7 +102,6 @@ class Upgrader extends Abstracts\Plugin_Version_Checker {
 			wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' );
 			// Assume success because they could've been deleted already.
 			// It also isn't problematic if they actually failed.
-			return true;
 		}
 
 		// No upgrade needed, so consider success.

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -11,14 +11,14 @@ namespace PTC_Completionist;
 
 defined( 'ABSPATH' ) || die();
 
-require_once PLUGIN_PATH . 'src/includes/abstracts/class-plugin-version-upgrader.php';
+require_once PLUGIN_PATH . 'src/includes/abstracts/class-plugin-version-checker.php';
 
 /**
  * Static class to handle plugin upgrades.
  *
  * @since [unreleased]
  */
-class Upgrader extends Abstracts\Plugin_Version_Upgrader {
+class Upgrader extends Abstracts\Plugin_Version_Checker {
 
 	/**
 	 * The option name storing the last successfully upgraded

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Upgrader class
+ *
+ * @since [unreleased]
+ */
+
+declare(strict_types=1);
+
+namespace PTC_Completionist;
+
+defined( 'ABSPATH' ) || die();
+
+require_once PLUGIN_PATH . 'src/includes/abstracts/class-plugin-version-upgrader.php';
+
+/**
+ * Static class to handle plugin upgrades.
+ *
+ * @since [unreleased]
+ */
+class Upgrader extends Abstracts\Plugin_Version_Upgrader {
+
+	/**
+	 * The option name storing the last successfully upgraded
+	 * plugin version.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @var string VERSION_OPTION_NAME
+	 */
+	const VERSION_OPTION_NAME = '_ptc_completionist_upgraded_version';
+
+	/**
+	 * Hooks functionality into the WordPress execution flow.
+	 *
+	 * @since [unreleased]
+	 */
+	public static function register() {
+		add_action( 'plugins_loaded', __CLASS__ . '::maybe_run' );
+	}
+
+	/**
+	 * Checks the last successfully upgraded plugin version and
+	 * runs the upgrade processes if needed.
+	 *
+	 * @since [unreleased]
+	 */
+	public static function maybe_run() {
+
+		$last_upgraded_version = (int) get_option( static::VERSION_OPTION_NAME, 0 );
+
+		if ( PLUGIN_VERSION === $last_upgraded_version ) {
+			// Plugin state is up-to-date.
+			return;
+		} elseif ( version_compare( PLUGIN_VERSION, $last_upgraded_version, '>' ) ) {
+			// Plugin state is old and needs upgrade.
+			if ( static::upgrade_from_version( $last_upgraded_version, PLUGIN_VERSION ) ) {
+				// Update option on successful upgrade.
+				update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
+			}
+		} else {
+			/*
+			The plugin was rolled back to a previous version. This is
+			not recommended and usually signals that the user is
+			experiencing issues with the latest release.
+
+			This will likely cause old plugin data to be added back,
+			so the upgrade process should run again if the plugin is
+			updated again in the future.
+
+			EDGE CASE: This will not work for users who roll back to
+			versions prior to v4.0.0. That's because this class
+			was first introduced in v4.0.0, so the database option
+			will remain set as '4.0.0' because this code doesn't exist
+			in prior versions to fix the option value. Using such an
+			old version of the plugin will also cause the uninstall
+			script to be insufficient.
+
+			If this causes issues, the user should simply uninstall
+			the plugin (from the latest installed version, if possible)
+			to completely remove all data and reset the plugin's state.
+			*/
+			update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
+		}
+	}
+
+	/**
+	 * Resets the upgrader by clearing its data.
+	 *
+	 * @since [unreleased]
+	 */
+	public static function reset() {
+		delete_option( static::VERSION_OPTION_NAME );
+	}
+
+	/**
+	 * Runs migration processes to upgrade the plugin's state from
+	 * the specified version.
+	 *
+	 * @since [unreleased]
+	 *
+	 * @param string $old_version The plugin version string from
+	 * which to upgrade.
+	 *
+	 * @return bool If upgraded successfully.
+	 */
+	private static function upgrade_from_version( string $old_version ) : bool {
+
+		if ( version_compare( $old_version, '4.0.0', '<' ) ) {
+			// First upgrade process, so the $old_version is always zero.
+			// v4.0.0 is when plugin hosting changed from
+			// <purpleturtlecreative.com> to <wordpress.org> which
+			// removed the YahnisElsts/plugin-update-checker package.
+			if (
+				true === delete_site_option( 'external_updates-completionist' ) &&
+				false !== wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' )
+			) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		// No upgrade needed, so consider success.
+		return true;
+	}
+}//end class

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -79,12 +79,15 @@ class Upgrader extends Abstracts\Plugin_Version_Checker {
 	 */
 	protected static function upgrade_from_version( string $old_version ) : bool {
 
+		$success = true;
+
 		if ( version_compare( $old_version, '3.7.0', '<' ) ) {
-			// Check installed database version.
+			// v3.7.0 is when the new Request_Token class replaced
+			// the postmeta-based Request_Tokens class. If successful,
+			// the new class installs custom database tables to work.
 			require_once PLUGIN_PATH . 'src/includes/class-database-manager.php';
 			Database_Manager::init();
-			$db_version = Database_Manager::get_installed_version();
-			if ( $db_version >= 2 ) {
+			if ( Database_Manager::get_installed_version() >= 2 ) {
 				// Now that the custom request tokens database table
 				// is successfully installed, all deprecated Request
 				// Tokens (stored within postmeta) should be purged.
@@ -94,17 +97,13 @@ class Upgrader extends Abstracts\Plugin_Version_Checker {
 		}
 
 		if ( version_compare( $old_version, '4.0.0', '<' ) ) {
-			// First upgrade process, so the $old_version is always zero.
 			// v4.0.0 is when plugin hosting changed from
 			// <purpleturtlecreative.com> to <wordpress.org> which
 			// removed the YahnisElsts/plugin-update-checker package.
 			delete_site_option( 'external_updates-completionist' );
 			wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' );
-			// Assume success because they could've been deleted already.
-			// It also isn't problematic if they actually failed.
 		}
 
-		// No upgrade needed, so consider success.
-		return true;
+		return $success;
 	}
 }//end class

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -26,72 +26,18 @@ class Upgrader extends Abstracts\Plugin_Version_Upgrader {
 	 *
 	 * @since [unreleased]
 	 *
-	 * @var string VERSION_OPTION_NAME
+	 * @var string $upgraded_version_option
 	 */
-	const VERSION_OPTION_NAME = '_ptc_completionist_upgraded_version';
+	protected static $upgraded_version_option = '_ptc_completionist_upgraded_version';
 
 	/**
-	 * Hooks functionality into the WordPress execution flow.
+	 * The current running plugin version.
 	 *
 	 * @since [unreleased]
-	 */
-	public static function register() {
-		add_action( 'plugins_loaded', __CLASS__ . '::maybe_run' );
-	}
-
-	/**
-	 * Checks the last successfully upgraded plugin version and
-	 * runs the upgrade processes if needed.
 	 *
-	 * @since [unreleased]
+	 * @var string $current_plugin_version
 	 */
-	public static function maybe_run() {
-
-		$last_upgraded_version = (int) get_option( static::VERSION_OPTION_NAME, 0 );
-
-		if ( PLUGIN_VERSION === $last_upgraded_version ) {
-			// Plugin state is up-to-date.
-			return;
-		} elseif ( version_compare( PLUGIN_VERSION, $last_upgraded_version, '>' ) ) {
-			// Plugin state is old and needs upgrade.
-			if ( static::upgrade_from_version( $last_upgraded_version, PLUGIN_VERSION ) ) {
-				// Update option on successful upgrade.
-				update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
-			}
-		} else {
-			/*
-			The plugin was rolled back to a previous version. This is
-			not recommended and usually signals that the user is
-			experiencing issues with the latest release.
-
-			This will likely cause old plugin data to be added back,
-			so the upgrade process should run again if the plugin is
-			updated again in the future.
-
-			EDGE CASE: This will not work for users who roll back to
-			versions prior to v4.0.0. That's because this class
-			was first introduced in v4.0.0, so the database option
-			will remain set as '4.0.0' because this code doesn't exist
-			in prior versions to fix the option value. Using such an
-			old version of the plugin will also cause the uninstall
-			script to be insufficient.
-
-			If this causes issues, the user should simply uninstall
-			the plugin (from the latest installed version, if possible)
-			to completely remove all data and reset the plugin's state.
-			*/
-			update_option( static::VERSION_OPTION_NAME, PLUGIN_VERSION, true );
-		}
-	}
-
-	/**
-	 * Resets the upgrader by clearing its data.
-	 *
-	 * @since [unreleased]
-	 */
-	public static function reset() {
-		delete_option( static::VERSION_OPTION_NAME );
-	}
+	protected static $current_plugin_version = PLUGIN_VERSION;
 
 	/**
 	 * Runs migration processes to upgrade the plugin's state from
@@ -104,21 +50,16 @@ class Upgrader extends Abstracts\Plugin_Version_Upgrader {
 	 *
 	 * @return bool If upgraded successfully.
 	 */
-	private static function upgrade_from_version( string $old_version ) : bool {
+	protected static function upgrade_from_version( string $old_version ) : bool {
 
 		if ( version_compare( $old_version, '4.0.0', '<' ) ) {
 			// First upgrade process, so the $old_version is always zero.
 			// v4.0.0 is when plugin hosting changed from
 			// <purpleturtlecreative.com> to <wordpress.org> which
 			// removed the YahnisElsts/plugin-update-checker package.
-			if (
-				true === delete_site_option( 'external_updates-completionist' ) &&
-				false !== wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' )
-			) {
-				return true;
-			} else {
-				return false;
-			}
+			delete_site_option( 'external_updates-completionist' );
+			wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' );
+			return true; // Assume success.
 		}
 
 		// No upgrade needed, so consider success.

--- a/src/public/class-upgrader.php
+++ b/src/public/class-upgrader.php
@@ -59,7 +59,9 @@ class Upgrader extends Abstracts\Plugin_Version_Checker {
 			// removed the YahnisElsts/plugin-update-checker package.
 			delete_site_option( 'external_updates-completionist' );
 			wp_clear_scheduled_hook( 'puc_cron_check_updates-completionist' );
-			return true; // Assume success.
+			// Assume success because they could've been deleted already.
+			// It also isn't problematic if they actually failed.
+			return true;
 		}
 
 		// No upgrade needed, so consider success.


### PR DESCRIPTION
- [x] Uninstall all new options (`Admin_Notices::delete_all()` and `Plugin_Version_Checker::delete_data()`)
- [x] Register REST API endpoint to handle WordPress notice dismissal
- [x] Output inline JavaScript to handle AJAX WordPress notice dismissal
- [x] Ensure all code is documented
- [x] Ensure all `@todo` comments are resolved
