### PR TITLE
#244 support v1 project and task URLs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@
 - New PHP filter hook `ptc_completionist_update_settings_{$request['action']}_response` to handle the response of an unsupported action in the `PUT /v1/settings` endpoint.
 - New JavaScript filter hook `AdminSettingsScreen_menu_items` to add custom screens to the plugin settings admin page.
 
+#### Deprecated
+
+- Passing a string `$task_gid` to `HTML_Builder::get_task_action_link()` which results in a v0 Asana task link to be returned. A `$task` object with the `permalink_url` field fetched from the Asana API is now preferred to ensure task URLs automatically follow Asana's current URL schema.
+
 #### Fixed
 
 - Error message "[object Object]" instead of a human-readable message for some errors that can occur when loading or updating plugin settings.
@@ -17,6 +21,7 @@
 #### Security
 
 - Some merge fields in Automations are no longer parsed: `{user.user_pass}`, `{user.user_activation_key}`, `{user.session_tokens}`, `{user._ptc_asana_pat}`
+- Removed `action_link` from frontend response when displaying the `[ptc_asana_task]` shortcode.
 
 ### 4.5.0 - 2024-12-01
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 #### Added
 
+- Forward compatibility support for Asana's v1 URL schema, which is currently expected to begin gradual rollout on February 17, 2025.
 - New PHP filter hook `ptc_completionist_task_data` to alter the returned Asana task data from REST API requests for a single task.
 - New PHP filter hook `ptc_completionist_frontend_api_data_nonce_actions` to register frontend actions for which to generate nonces.
 - New PHP filter hook `ptc_completionist_frontend_api_data_selected_keys_for_{$context}` for which frontend data keys should be selected for output per context.

--- a/changelog.md
+++ b/changelog.md
@@ -9,9 +9,14 @@
 - New PHP filter hook `ptc_completionist_update_settings_{$request['action']}_response` to handle the response of an unsupported action in the `PUT /v1/settings` endpoint.
 - New JavaScript filter hook `AdminSettingsScreen_menu_items` to add custom screens to the plugin settings admin page.
 
+#### Changed
+
+- Asana "view task" links are no longer guaranteed to open in focus mode due to now using Asana's provided permalink URLs for tasks.
+- The Dashboard Widget, Pinned Tasks metabox, and Automations admin script and style assets now use their respective build versions rather than the Completionist plugin's version.
+
 #### Deprecated
 
-- Passing a string `$task_gid` to `HTML_Builder::get_task_action_link()` which results in a v0 Asana task link to be returned. A `$task` object with the `permalink_url` field fetched from the Asana API is now preferred to ensure task URLs automatically follow Asana's current URL schema.
+- Various functions and arguments which result in a v0 Asana task link to be used. The `permalink_url` field fetched from the Asana API is now preferred to ensure task URLs automatically follow Asana's current URL schema.
 
 #### Fixed
 

--- a/src/admin/class-admin-pages.php
+++ b/src/admin/class-admin-pages.php
@@ -191,7 +191,7 @@ class Admin_Pages {
 					'ptc-completionist_DashboardWidget',
 					PLUGIN_URL . '/build/index_DashboardWidget.jsx.js',
 					$asset_file['dependencies'],
-					PLUGIN_VERSION,
+					$asset_file['version'],
 					true
 				);
 				$js_data = wp_json_encode( static::get_frontend_task_data() );
@@ -205,7 +205,7 @@ class Admin_Pages {
 					'ptc-completionist_DashboardWidget',
 					PLUGIN_URL . '/build/index_DashboardWidget.jsx.css',
 					array(),
-					PLUGIN_VERSION
+					$asset_file['version']
 				);
 				break;
 
@@ -217,7 +217,7 @@ class Admin_Pages {
 					'ptc-completionist-pinned-tasks',
 					PLUGIN_URL . '/build/index_PinnedTasksMetabox.jsx.js',
 					$asset_file['dependencies'],
-					PLUGIN_VERSION,
+					$asset_file['version'],
 					true
 				);
 				wp_enqueue_style( 'fontawesome-5' );
@@ -225,7 +225,7 @@ class Admin_Pages {
 					'ptc-completionist-pinned-tasks',
 					PLUGIN_URL . '/build/index_PinnedTasksMetabox.jsx.css',
 					array(),
-					PLUGIN_VERSION
+					$asset_file['version']
 				);
 				$js_data = wp_json_encode( static::get_frontend_task_data() );
 				wp_add_inline_script(
@@ -301,7 +301,7 @@ class Admin_Pages {
 						'ptc-completionist_Automations',
 						PLUGIN_URL . '/build/index_Automations.jsx.js',
 						$asset_file['dependencies'],
-						PLUGIN_VERSION,
+						$asset_file['version'],
 						true
 					);
 					wp_localize_script(
@@ -345,7 +345,7 @@ class Admin_Pages {
 			'ptc-completionist-block-editor',
 			PLUGIN_URL . '/build/index_BlockEditor.jsx.js',
 			$asset_file['dependencies'],
-			PLUGIN_VERSION,
+			$asset_file['version'],
 			true
 		);
 		wp_enqueue_style( 'fontawesome-5' );
@@ -353,7 +353,7 @@ class Admin_Pages {
 			'ptc-completionist-block-editor',
 			PLUGIN_URL . '/build/index_BlockEditor.jsx.css',
 			array(),
-			PLUGIN_VERSION
+			$asset_file['version']
 		);
 		$js_data = wp_json_encode( static::get_frontend_task_data() );
 		wp_add_inline_script(

--- a/src/components/task/TaskActions.jsx
+++ b/src/components/task/TaskActions.jsx
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
 
 import { useCallback, useContext } from '@wordpress/element';
 
-export default function TaskActions({taskGID, processingStatus}) {
+export default function TaskActions({taskGID, taskPermalinkUrl, processingStatus}) {
 	const { deleteTask, unpinTask, removeTask, setTaskProcessingStatus } = useContext(TaskContext);
 	const currentPostId = useSelect(selectEditorCurrentPostId);
 
@@ -40,7 +40,7 @@ export default function TaskActions({taskGID, processingStatus}) {
 		});
 	}, [processingStatus, setTaskProcessingStatus, removeTask]);
 
-	const task_url = getTaskUrl(taskGID);
+	const task_url = taskPermalinkUrl || getTaskUrl(taskGID);
 
 	const unpinIcon = ('unpinning' === processingStatus) ? 'fa-sync-alt fa-spin' : 'fa-thumbtack';
 	const deleteIcon = ('deleting' === processingStatus) ? 'fa-sync-alt fa-spin' : 'fa-minus';

--- a/src/components/task/TaskRow.jsx
+++ b/src/components/task/TaskRow.jsx
@@ -88,7 +88,7 @@ export default function TaskRow({task}) {
 
 			<div className="actions">
 				<a className="cta-button" href={task.action_link.href} target={task.action_link.target}>{task.action_link.label} <i className="fas fa-long-arrow-alt-right"></i></a>
-				<TaskActions taskGID={task.gid} processingStatus={task.processingStatus} />
+				<TaskActions taskGID={task.gid} taskPermalinkUrl={task?.permalink_url} processingStatus={task.processingStatus} />
 			</div>
 
 		</div>

--- a/src/components/task/util.js
+++ b/src/components/task/util.js
@@ -2,10 +2,10 @@
  * Utility functions unrelated to application state.
  */
 
-import { isImage, isVideo, isFileType } from '../attachment/util.jsx';
+import { isImage } from '../attachment/util.jsx';
 
 export function getTaskUrl(taskGID) {
-	// @TODO - Prefer task permalink_url ..?
+	window.console.warn( 'getTaskUrl() is deprecated since v[unreleased]. Please use the task object\'s `permalink_url` field instead.' );
 	return `https://app.asana.com/0/0/${taskGID}/f`;
 }
 

--- a/src/components/task/util.js
+++ b/src/components/task/util.js
@@ -5,13 +5,25 @@
 import { isImage, isVideo, isFileType } from '../attachment/util.jsx';
 
 export function getTaskUrl(taskGID) {
+	// @TODO - Prefer task permalink_url ..?
 	return `https://app.asana.com/0/0/${taskGID}/f`;
 }
 
-export function getTaskGIDFromTaskUrl(url) {
+export function getTaskGIDFromTaskUrl(taskLink) {
 
-	const matches = url.trim().match(/\/(\d+)\/.$/);
-	if ( matches && matches[1] ) {
+	let matches;
+
+	if (
+		( matches = taskLink.match(/\/task\/([0-9]+)/) ) &&
+		matches[1]
+	) {
+		// Task link in URL schema v1 (eg. https://app.asana.com/1/<workspace_id>/project/<project_id>/task/<task_id>)
+		return matches[1];
+	} else if (
+		( matches = taskLink.match(/\/([0-9]+)\/.$/) ) &&
+		matches[1]
+	) {
+		// Task link in URL schema v0 (eg. https://app.asana.com/0/<project_id>/<task_id>/f)
 		return matches[1];
 	}
 

--- a/src/includes/class-asana-interface.php
+++ b/src/includes/class-asana-interface.php
@@ -1402,8 +1402,7 @@ class Asana_Interface {
 				}
 			}
 
-			// @TODO
-			$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
+			$task->action_link = HTML_Builder::get_task_action_link( $task );
 
 			return $task;
 		} catch ( \Exception $e ) {
@@ -1533,8 +1532,7 @@ class Asana_Interface {
 		$site_tasks = $asana->tasks->findByTag( $site_tag_gid, $params, $options );
 		$all_tasks = array();
 		foreach ( $site_tasks as $task ) {
-			// @TODO
-			$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
+			$task->action_link = HTML_Builder::get_task_action_link( $task );
 			$all_tasks[ $task->gid ] = $task;
 		}
 
@@ -1916,8 +1914,7 @@ class Asana_Interface {
 			throw new \Exception( 'Unrecognized API response to create task.', 409 );
 		}
 
-		// @TODO
-		$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
+		$task->action_link = HTML_Builder::get_task_action_link( $task );
 
 		// Pin the task if desired.
 		if ( isset( $params['post_id'] ) ) {
@@ -2188,8 +2185,7 @@ class Asana_Interface {
 			throw new \Exception( 'Unrecognized API response to update task.', 409 );
 		}
 
-		// @TODO
-		$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
+		$task->action_link = HTML_Builder::get_task_action_link( $task );
 
 		return $task;
 	}

--- a/src/includes/class-asana-interface.php
+++ b/src/includes/class-asana-interface.php
@@ -26,11 +26,12 @@ class Asana_Interface {
 	/**
 	 * The ?opt_fields csv for Asana API requests.
 	 *
+	 * @since [unreleased] Added `permalink_url`.
 	 * @since 3.1.0
 	 *
 	 * @var string TASK_OPT_FIELDS
 	 */
-	public const TASK_OPT_FIELDS = 'name,completed,notes,due_on,assignee,assignee.name,workspace,tags';
+	public const TASK_OPT_FIELDS = 'name,completed,notes,due_on,assignee,assignee.name,workspace,tags,permalink_url';
 
 	/**
 	 * The $options array for \Asana\Client instantiation.
@@ -1401,6 +1402,7 @@ class Asana_Interface {
 				}
 			}
 
+			// @TODO
 			$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
 
 			return $task;
@@ -1531,6 +1533,7 @@ class Asana_Interface {
 		$site_tasks = $asana->tasks->findByTag( $site_tag_gid, $params, $options );
 		$all_tasks = array();
 		foreach ( $site_tasks as $task ) {
+			// @TODO
 			$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
 			$all_tasks[ $task->gid ] = $task;
 		}
@@ -1913,6 +1916,7 @@ class Asana_Interface {
 			throw new \Exception( 'Unrecognized API response to create task.', 409 );
 		}
 
+		// @TODO
 		$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
 
 		// Pin the task if desired.
@@ -2184,6 +2188,7 @@ class Asana_Interface {
 			throw new \Exception( 'Unrecognized API response to update task.', 409 );
 		}
 
+		// @TODO
 		$task->action_link = HTML_Builder::get_task_action_link( $task->gid );
 
 		return $task;

--- a/src/includes/class-asana-interface.php
+++ b/src/includes/class-asana-interface.php
@@ -511,6 +511,10 @@ class Asana_Interface {
 	 * Gets the external link to a user's task list in Asana for the chosen
 	 * workspace.
 	 *
+	 * Note that this is only useful to retrieve the currently authenticated
+	 * Asana user's task list. Retrieving the task list for another Asana user
+	 * results in a 403 Forbidden error from the Asana API.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param int $user_id Optional. The WordPress user's ID. Default 0 to use
@@ -519,7 +523,7 @@ class Asana_Interface {
 	 */
 	public static function get_task_list_external_link( int $user_id = 0 ) : string {
 
-		$user_gid = Options::get( Options::ASANA_USER_GID, $user_id );
+		$user_gid      = Options::get( Options::ASANA_USER_GID, $user_id );
 		$workspace_gid = Options::get( Options::ASANA_WORKSPACE_GID );
 		if ( '' === $workspace_gid || '' === $user_gid ) {
 			return '';
@@ -527,13 +531,13 @@ class Asana_Interface {
 
 		try {
 
-			$asana = self::get_client();
+			$asana  = self::get_client();
 			$params = array(
-				'workspace' => $workspace_gid,
+				'workspace'  => $workspace_gid,
 				'opt_fields' => 'gid',
 			);
 
-			$user_task_list = $asana->usertasklists->findByUser( $user_gid, $params );
+			$user_task_list     = $asana->usertasklists->findByUser( $user_gid, $params );
 			$user_task_list_gid = Options::sanitize( 'gid', $user_task_list->gid );
 			if ( empty( $user_task_list_gid ) ) {
 				return '';
@@ -541,7 +545,7 @@ class Asana_Interface {
 
 			return 'https://app.asana.com/0/' . $user_task_list_gid . '/list';
 		} catch ( \Exception $e ) {
-			error_log( 'Failed to retrieve user\'s task list link. Error ' . $e->getCode() . ': ' . $e->getMessage() );
+			wp_trigger_error( __FUNCTION__, HTML_Builder::format_error_string( $e, 'Failed to retrieve user\'s task list link.' ) );
 		}
 
 		return '';
@@ -550,6 +554,9 @@ class Asana_Interface {
 	/**
 	 * Extracts a task gid from a copied task link.
 	 *
+	 * @link https://forum.asana.com/t/upcoming-new-v1-asana-url-format-in-the-browser/1011489
+	 *
+	 * @since [unreleased] Support v1 Asana link schema.
 	 * @since 1.0.0
 	 *
 	 * @param string $task_link The task link provided by clicking the chainlink
@@ -562,9 +569,22 @@ class Asana_Interface {
 		$task_link = filter_var( wp_unslash( $task_link ), FILTER_SANITIZE_URL );
 
 		if (
+			preg_match( '/\/task\/([0-9]+)/', $task_link, $matches ) === 1
+			&& ! empty( $matches[1] )
+		) {
+			/*
+			 * Any link in URL schema v1.
+			 * eg. https://app.asana.com/1/<workspace_id>/project/<project_id>/task/<task_id>
+			 */
+			return Options::sanitize( 'gid', $matches[1] );
+		} elseif (
 			preg_match( '/\/([0-9]+)\/.$/', $task_link, $matches ) === 1
 			&& ! empty( $matches[1] )
 		) {
+			/*
+			 * Task link in URL schema v0.
+			 * eg. https://app.asana.com/0/<project_id>/<task_id>/f
+			 */
 			return Options::sanitize( 'gid', $matches[1] );
 		}
 
@@ -574,6 +594,9 @@ class Asana_Interface {
 	/**
 	 * Parses project view information from an Asana project link.
 	 *
+	 * @link https://forum.asana.com/t/upcoming-new-v1-asana-url-format-in-the-browser/1011489
+	 *
+	 * @since [unreleased] Support v1 Asana link schema.
 	 * @since 3.4.0
 	 *
 	 * @param string $project_link An Asana project URL.
@@ -585,9 +608,17 @@ class Asana_Interface {
 
 		$project_link = esc_url_raw( $project_link );
 
-		if ( preg_match( '/\/([0-9]+)\/([a-z]+)$/', $project_link, $matches ) ) {
+		if ( preg_match( '/\/project\/([0-9]+)/', $project_link, $matches ) ) {
 			/*
-			 * Copied project URL from web browser address bar.
+			 * Any link in URL schema v1.
+			 * eg. https://app.asana.com/1/<workspace_id>/project/<project_id>
+			 */
+			if ( ! empty( $matches[1] ) ) {
+				$parsed_project_data['gid'] = Options::sanitize( 'gid', $matches[1] );
+			}
+		} elseif ( preg_match( '/\/([0-9]+)\/([a-z]+)$/', $project_link, $matches ) ) {
+			/*
+			 * Copied project URL v0 from web browser address bar.
 			 * ex. https://app.asana.com/0/1234567890/list
 			 */
 			if ( ! empty( $matches[1] ) ) {
@@ -598,12 +629,12 @@ class Asana_Interface {
 			}
 		} elseif ( preg_match( '/\/([0-9]+)\/[0-9]+$/', $project_link, $matches ) ) {
 			/*
-			 * Copied project URL from project details dropdown in Asana.
+			 * Copied project URL v0 from project details dropdown in Asana.
 			 * ex. https://app.asana.com/0/1234567890/1234567890
-				 *
-				 * Or new project URL from the web browser address bar
-				 * with a project view GID.
-				 * ex. https://app.asana.com/0/1234567890/2345678901
+			 *
+			 * Or new project URL v0 from the web browser address bar
+			 * with a project view GID.
+			 * ex. https://app.asana.com/0/1234567890/2345678901
 			 */
 			if ( ! empty( $matches[1] ) ) {
 				$parsed_project_data['gid'] = Options::sanitize( 'gid', $matches[1] );

--- a/src/includes/class-html-builder.php
+++ b/src/includes/class-html-builder.php
@@ -168,6 +168,7 @@ class HTML_Builder {
 	 * @return string The URL to the task in Asana. Default ''.
 	 */
 	public static function get_asana_task_url( string $task_gid ) : string {
+		// @TODO - Prefer task permalink_url ..?
 
 		$task_gid = Options::sanitize( 'gid', $task_gid );
 
@@ -220,7 +221,7 @@ class HTML_Builder {
 		// Use Asana task link if no pinned post.
 		if ( empty( $task_action_link['href'] ) || empty( $task_action_link['label'] ) ) {
 			$task_action_link = array(
-				'href'   => self::get_asana_task_url( $task_gid ),
+				'href'   => self::get_asana_task_url( $task_gid ), // @TODO - Prefer task permalink_url ..?
 				'label'  => 'View in Asana',
 				'target' => '_asana',
 			);

--- a/src/includes/class-html-builder.php
+++ b/src/includes/class-html-builder.php
@@ -162,12 +162,19 @@ class HTML_Builder {
 	/**
 	 * Gets an Asana task URL.
 	 *
+	 * @deprecated [unreleased] Use the Asana task object's `permalink_url` field instead.
 	 * @since 1.0.0
 	 *
 	 * @param string $task_gid The GID of the task to link.
 	 * @return string The URL to the task in Asana. Default ''.
 	 */
 	public static function get_asana_task_url( string $task_gid ) : string {
+
+		_deprecated_function(
+			__FUNCTION__,
+			'[unreleased]',
+			'the Asana task object\'s `permalink_url` field'
+		);
 
 		$task_gid = Options::sanitize( 'gid', $task_gid );
 
@@ -181,12 +188,12 @@ class HTML_Builder {
 	/**
 	 * Gets the task action link information.
 	 *
-	 * @since [unreleased] Deprecated string $task_gid value. An Asana $task \stdClass
-	 * object is now preferred with `gid` and `permalink_url` field values.
+	 * @since [unreleased] The string $task_gid is deprecated. Use an Asana task \stdClass object instead,
+	 * which should contain `gid` and `permalink_url` fields.
 	 * @since 3.1.0
 	 *
-	 * @param string|\stdClass $task The Asana task GID string or task object with
-	 * `gid` and `permalink_url` field values.
+	 * @param string|\stdClass $task The Asana task GID string (deprecated) or an Asana task object
+	 * with `gid` and `permalink_url` fields.
 	 */
 	public static function get_task_action_link( string|\stdClass $task ) : array {
 

--- a/src/public/rest-api/class-tasks.php
+++ b/src/public/rest-api/class-tasks.php
@@ -243,6 +243,10 @@ class Tasks {
 				);
 			}
 
+			if ( 'shortcode_ptc_asana_task' === $args['_cache_key'] ) {
+				unset( $task->action_link ); // The shortcode does not need this information for display.
+			}
+
 			// Localize task.
 			Asana_Interface::localize_task( $task, false );
 


### PR DESCRIPTION
**Affected functionality:**
- Task action links in Dashboard Widget and Pinned Tasks metabox
    - On initial display
    - After updating by clicking Mark Complete
    - After pinning to post
    - After pinning newly created task to post
- Removed task action link data from frontend API response when displaying `[ptc_asana_task]` shortcode since it doesn't use that information and those links typically aren't publicly accessible/useful anyways